### PR TITLE
:zap: improvements for test automation and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,50 +49,50 @@ are included.
 
 | Type                  | Version | Info                                     | 
 |-----------------------|---------|------------------------------------------|
-| kotlin                | 1.9.23 | used in kotlin compiler und kotlin libs. |
-| java                  | 17 | compile target                           |
-| kotlinx-serialization | 1.6.0 | compiler plugin                          |
-| kotlin-logging        | 3.0.5 | logging support                          |
+| kotlin                | 1.9.23  | used in kotlin compiler und kotlin libs. |
+| java                  | 17      | compile target                           |
+| kotlinx-serialization | 1.6.0   | compiler plugin                          |
+| kotlin-logging        | 3.0.5   | logging support                          |
 
 ## Libs
 
-| Lib | Version | Info |
-|-----|---------|------|
-| junit5 | 5.10.2 | bom dependency, unit testing |
+| Lib    | Version  | Info                         |
+|--------|----------|------------------------------|
+| junit5 | 5.10.2   | bom dependency, unit testing |
 
 ## Plugins
 
 see [official plugins](https://maven.apache.org/plugins/index.html)
 
-| Plugin                                                                                                                    | Version | Info                                        |
-|---------------------------------------------------------------------------------------------------------------------------|---------|---------------------------------------------|
-| [maven-compiler](https://maven.apache.org/plugins/maven-compiler-plugin/)                                                 | 3.13.0  | disabling java compiler for kotlin projects |
-| [maven-javadoc](https://maven.apache.org/plugins/maven-javadoc-plugin/)                                                   | 3.6.3   | include javadoc                             |
-| [dokka](https://kotlinlang.org/docs/dokka-maven.html#apply-dokka)                                                         | 1.9.20  | use dokka for javadoc                       |
-| [avro-maven](https://avro.apache.org/docs/1.11.1/getting-started-java/)                                                   | 1.11.3  | avro code generation                        |
-| [maven-clean](https://maven.apache.org/plugins/maven-clean-plugin/)                                                       | 3.3.2   | clean project                               |
-| [maven-dependency](https://maven.apache.org/plugins/maven-dependency-plugin/)                                             | 3.6.1   | check/update dependency versions            |
-| [maven-deploy](https://maven.apache.org/plugins/maven-deploy-plugin/)                                                     | 3.1.1   | -                                           |
-| [maven-enforcer](https://maven.apache.org/enforcer/maven-enforcer-plugin/)                                                | 3.4.1   | enforce project setup                       |
-| [maven-failsafe](https://maven.apache.org/surefire/maven-failsafe-plugin/)                                                | 3.2.5   | testing                                     |
-| [maven-gpg](https://maven.apache.org/plugins/maven-gpg-plugin/)                                                           | 3.2.1   | sign artifacts for release                  |
-| [maven-install](https://maven.apache.org/plugins/maven-install-plugin/)                                                   | 3.1.1   | -                                           |
-| [maven-jar-plugin](https://maven.apache.org/plugins/maven-jar-plugin/)                                                    | 3.3.0   | -                                           |
-| [maven-resources](https://maven.apache.org/plugins/maven-resources-plugin/)                                               | 3.3.1   | filter resources                            |
-| [maven-surefire](https://maven.apache.org/surefire/maven-surefire-plugin/)                                                | 3.2.5   | testing                                     |
-| [build-helper](https://www.mojohaus.org/build-helper-maven-plugin/)                                                       | 3.5.0   | define source directories                   |
-| [gitflow-maven](https://aleksandr-m.github.io/gitflow-maven-plugin/)                                                      | 1.21.0  | gitflow relase master/develop/release       |
-| [jacoco-maven](https://www.eclemma.org/jacoco/trunk/doc/maven.html)                                                       | 0.8.11  | test reports                                |
-| [jgiven-maven](https://jgiven.org/userguide/#_maven)                                                                      | 1.3.1   | jgiven test reports                         |
-| [openapi-generator](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin) | 7.4.0   | openapi/swagger code generation             |
-| [properties-maven](https://www.mojohaus.org/properties-maven-plugin/)                                                     | 1.2.1   | generate build properties for project       |
-| [versions-maven](https://www.mojohaus.org/versions/versions-maven-plugin/index.html)                                      | 2.16.2  | modify versions of project                  |
-| [nexus-staging-maven](https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md)           | 1.6.13  | release on maven central                    |
+| Plugin                                                                                                                       | Version | Info                                        |
+|------------------------------------------------------------------------------------------------------------------------------|---------|---------------------------------------------|
+| [maven-compiler](https://maven.apache.org/plugins/maven-compiler-plugin/)                                                    | 3.13.0  | disabling java compiler for kotlin projects |
+| [maven-javadoc](https://maven.apache.org/plugins/maven-javadoc-plugin/)                                                      | 3.6.3   | include javadoc                             |
+| [dokka](https://kotlinlang.org/docs/dokka-maven.html#apply-dokka)                                                            | 1.9.20  | use dokka for javadoc                       |
+| [avro-maven](https://avro.apache.org/docs/1.11.1/getting-started-java/)                                                      | 1.11.3  | avro code generation                        |
+| [maven-clean](https://maven.apache.org/plugins/maven-clean-plugin/)                                                          | 3.3.2   | clean project                               |
+| [maven-dependency](https://maven.apache.org/plugins/maven-dependency-plugin/)                                                | 3.6.1   | check/update dependency versions            |
+| [maven-deploy](https://maven.apache.org/plugins/maven-deploy-plugin/)                                                        | 3.1.1   | -                                           |
+| [maven-enforcer](https://maven.apache.org/enforcer/maven-enforcer-plugin/)                                                   | 3.4.1   | enforce project setup                       |
+| [maven-failsafe](https://maven.apache.org/surefire/maven-failsafe-plugin/)                                                   | 3.2.5   | testing                                     |
+| [maven-gpg](https://maven.apache.org/plugins/maven-gpg-plugin/)                                                              | 3.2.1   | sign artifacts for release                  |
+| [maven-install](https://maven.apache.org/plugins/maven-install-plugin/)                                                      | 3.1.1   | -                                           |
+| [maven-jar-plugin](https://maven.apache.org/plugins/maven-jar-plugin/)                                                       | 3.3.0   | -                                           |
+| [maven-resources](https://maven.apache.org/plugins/maven-resources-plugin/)                                                  | 3.3.1   | filter resources                            |
+| [maven-surefire](https://maven.apache.org/surefire/maven-surefire-plugin/)                                                   | 3.2.5   | testing                                     |
+| [build-helper](https://www.mojohaus.org/build-helper-maven-plugin/)                                                          | 3.5.0   | define source directories                   |
+| [gitflow-maven](https://aleksandr-m.github.io/gitflow-maven-plugin/)                                                         | 1.21.0  | gitflow relase master/develop/release       |
+| [jacoco-maven](https://www.eclemma.org/jacoco/trunk/doc/maven.html)                                                          | 0.8.11  | test reports                                |
+| [jgiven-maven](https://jgiven.org/userguide/#_maven)                                                                         | 1.3.1   | jgiven test reports                         |
+| [openapi-generator](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin)    | 7.4.0   | openapi/swagger code generation             |
+| [properties-maven](https://www.mojohaus.org/properties-maven-plugin/)                                                        | 1.2.1   | generate build properties for project       |
+| [versions-maven](https://www.mojohaus.org/versions/versions-maven-plugin/index.html)                                         | 2.16.2  | modify versions of project                  |
+| [nexus-staging-maven](https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md)              | 1.6.13  | release on maven central                    |
 
 
-## Release
+## Release a new version
 
-1. close milestone
+1. close milestone in GitHub
 1. on local console: `mvn release:start` - wait for action
 1. on local console: `mvn release:finish` - wait for action - sonatype pipeline will run
-1. github release - publish
+1. publish a release on GitHub (prepared version is in drafts)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ see [official plugins](https://maven.apache.org/plugins/index.html)
 | [maven-deploy](https://maven.apache.org/plugins/maven-deploy-plugin/)                                                        | 3.1.1   | -                                           |
 | [maven-enforcer](https://maven.apache.org/enforcer/maven-enforcer-plugin/)                                                   | 3.4.1   | enforce project setup                       |
 | [maven-failsafe](https://maven.apache.org/surefire/maven-failsafe-plugin/)                                                   | 3.2.5   | testing                                     |
-| [maven-gpg](https://maven.apache.org/plugins/maven-gpg-plugin/)                                                              | 3.2.1   | sign artifacts for release                  |
+| [maven-gpg](https://maven.apache.org/plugins/maven-gpg-plugin/)                                                              | 3.2.3   | sign artifacts for release                  |
 | [maven-install](https://maven.apache.org/plugins/maven-install-plugin/)                                                      | 3.1.1   | -                                           |
 | [maven-jar-plugin](https://maven.apache.org/plugins/maven-jar-plugin/)                                                       | 3.3.0   | -                                           |
 | [maven-resources](https://maven.apache.org/plugins/maven-resources-plugin/)                                                  | 3.3.1   | filter resources                            |

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,8 @@
     <kp.compile.useIncrementalKotlinCompiler>false</kp.compile.useIncrementalKotlinCompiler>
     <kp.patternClassITest>**/*ITest.*</kp.patternClassITest>
     <kp.patternClassTCTest>**/*TCTest.*</kp.patternClassTCTest>
-    <kp.javaOpenModules>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED</kp.javaOpenModules>
+    <kp.javaOpenModules>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED
+    </kp.javaOpenModules>
     <kp.skipITests>false</kp.skipITests>
 
     <!-- LANGUAGE VERSIONS -->
@@ -468,25 +469,25 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.2.5</version>
-          <configuration>
-            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-            <skip>${kp.skipITests}</skip>
-            <includes>
-              <include>${kp.patternClassITest}</include>
-              <include>${kp.patternClassTCTest}</include>
-            </includes>
-            <!--suppress UnresolvedMavenProperty -->
-            <argLine>${failsafeArgLine} ${kp.javaOpenModules} -Djava.awt.headless=true -XX:+StartAttachListener</argLine>
-            <systemPropertyVariables>
-              <jgiven.report.dir>${project.build.directory}/jgiven-reports/json</jgiven.report.dir>
-            </systemPropertyVariables>
-          </configuration>
           <executions>
             <execution>
               <id>integration-tests</id>
               <goals>
                 <goal>integration-test</goal>
               </goals>
+              <configuration>
+                <skip>${kp.skipITests}</skip>
+                <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                <includes>
+                  <include>${kp.patternClassITest}</include>
+                  <include>${kp.patternClassTCTest}</include>
+                </includes>
+                <!--suppress UnresolvedMavenProperty -->
+                <argLine>${failsafeArgLine} ${kp.javaOpenModules} -Djava.awt.headless=true -XX:+StartAttachListener</argLine>
+                <systemPropertyVariables>
+                  <jgiven.report.dir>${project.build.directory}/jgiven-reports/json</jgiven.report.dir>
+                </systemPropertyVariables>
+              </configuration>
             </execution>
           </executions>
         </plugin>
@@ -573,6 +574,7 @@
                 <goal>prepare-agent</goal>
               </goals>
               <configuration>
+                <!--suppress UnresolvedMavenProperty -->
                 <skip>${skipTests}</skip>
                 <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
                 <propertyName>surefireArgLine</propertyName>

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
   </dependencyManagement>
 
   <build>
-    <defaultGoal>clean package</defaultGoal>
+    <defaultGoal>clean jacoco:prepare-agent package</defaultGoal>
 
     <sourceDirectory>${kp.mainSources}</sourceDirectory>
     <testSourceDirectory>${kp.testSources}</testSourceDirectory>
@@ -652,6 +652,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.toolisticon.maven.parent</groupId>
   <artifactId>maven-parent-kotlin-base</artifactId>
-  <version>2024.3.3-SNAPSHOT</version>
+  <version>2024.4.0-SNAPSHOT</version>
 
   <name>Maven Parent - Kotlin Base</name>
   <description>Maven parent for a holistic kotlin lib project.</description>
@@ -31,8 +31,10 @@
     <!-- set to true to skip deployment (of submodule e.g.) -->
     <kp.plugin.skipDeploy>false</kp.plugin.skipDeploy>
     <kp.plugin.generateBackupPoms>false</kp.plugin.generateBackupPoms>
-
     <kp.compile.useIncrementalKotlinCompiler>false</kp.compile.useIncrementalKotlinCompiler>
+    <kp.patternClassITest>**/*ITest.*</kp.patternClassITest>
+    <kp.patternClassTCTest>**/*TCTest.*</kp.patternClassTCTest>
+    <kp.skipITests>false</kp.skipITests>
 
     <!-- LANGUAGE VERSIONS -->
     <kotlin.version>1.9.23</kotlin.version>
@@ -237,6 +239,9 @@
 
           <configuration>
             <jvmTarget>${java.version}</jvmTarget>
+            <apiVersion>1.9</apiVersion>
+            <languageVersion>1.9</languageVersion>
+
             <!-- Compiler plugins need to be configured on this level for IntelliJ to recognize them -->
             <compilerPlugins>
               <!--              <plugin>spring</plugin>-->
@@ -437,11 +442,45 @@
           </executions>
         </plugin>
 
+        <!-- [TEST] SUREFIRE (version, setup) -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+          <configuration>
+            <useSystemClassLoader>false</useSystemClassLoader>
+            <shutdown>kill</shutdown>
+            <runOrder>random</runOrder>
+            <excludes>
+              <exclude>${kp.patternClassITest}</exclude>
+              <exclude>${kp.patternClassTCTest}</exclude>
+            </excludes>
+            <!--suppress UnresolvedMavenProperty -->
+            <argLine>${surefireArgLine} -Djava.awt.headless=true -XX:+StartAttachListener --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+            <systemPropertyVariables>
+              <jgiven.report.dir>${project.build.directory}/jgiven-reports/json</jgiven.report.dir>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+
         <!-- [TEST] FAILSAFE (version, itest setup) -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.2.5</version>
+          <configuration>
+            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+            <skip>${kp.skipITests}</skip>
+            <includes>
+              <include>${kp.patternClassITest}</include>
+              <include>${kp.patternClassTCTest}</include>
+            </includes>
+            <!--suppress UnresolvedMavenProperty -->
+            <argLine>${failsafeArgLine} --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+            <systemPropertyVariables>
+              <jgiven.report.dir>${project.build.directory}/jgiven-reports/json</jgiven.report.dir>
+            </systemPropertyVariables>
+          </configuration>
           <executions>
             <execution>
               <id>integration-tests</id>
@@ -450,14 +489,6 @@
               </goals>
             </execution>
           </executions>
-          <configuration>
-            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
-            <!--suppress UnresolvedMavenProperty -->
-            <argLine>${failsafeArgLine}</argLine>
-            <systemPropertyVariables>
-              <jgiven.report.dir>${project.build.directory}/jgiven-reports</jgiven.report.dir>
-            </systemPropertyVariables>
-          </configuration>
         </plugin>
 
         <!-- [RELEASE] GPG (version)-->
@@ -465,6 +496,24 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
           <version>3.2.2</version>
+          <configuration>
+            <!-- pass -Dgpg.keyname=.. and -Dgpg.passphrase=... -->
+            <gpgArguments>
+              <arg>--batch</arg>
+              <arg>--yes</arg>
+              <arg>--pinentry-mode</arg>
+              <arg>loopback</arg>
+            </gpgArguments>
+          </configuration>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- INSTALL (version) -->
@@ -479,6 +528,20 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.3.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar-no-fork</goal>
+                <!-- also seen: jar ... which to choose? -->
+              </goals>
+              <configuration>
+                <attach>true</attach>
+                <forceCreation>true</forceCreation>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- RESOURCES (version, encoding) -->
@@ -491,25 +554,67 @@
           </configuration>
         </plugin>
 
-        <!-- [TEST] SUREFIRE (version, setup) -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
-
-          <configuration>
-            <useSystemClassLoader>false</useSystemClassLoader>
-            <shutdown>kill</shutdown>
-            <runOrder>random</runOrder>
-            <!--suppress UnresolvedMavenProperty -->
-            <argLine>${surefireArgLine} -Djava.awt.headless=true -XX:+StartAttachListener</argLine>
-            <systemPropertyVariables>
-              <jgiven.report.dir>${project.build.directory}/jgiven-reports</jgiven.report.dir>
-            </systemPropertyVariables>
-          </configuration>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
         </plugin>
 
         <!-- ========== //MAVEN OFFICIAL -->
+        <!-- [TEST] JACOCO (version, setup) -->
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.12</version>
+          <executions>
+            <execution>
+              <id>pre-unit-test</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+              <configuration>
+                <skip>${skipTests}</skip>
+                <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
+                <propertyName>surefireArgLine</propertyName>
+              </configuration>
+            </execution>
+            <execution>
+              <id>pre-integration-test</id>
+              <goals>
+                <goal>prepare-agent-integration</goal>
+              </goals>
+              <configuration>
+                <skip>${kp.skipITests}</skip>
+                <destFile>${project.build.directory}/coverage-reports/jacoco-it.exec</destFile>
+                <propertyName>failsafeArgLine</propertyName>
+              </configuration>
+            </execution>
+            <execution>
+              <id>post-unit-test</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <skip>${skipTests}</skip>
+                <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+                <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+              </configuration>
+            </execution>
+            <execution>
+              <id>post-integration-test</id>
+              <phase>post-integration-test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <skip>${kp.skipITests}</skip>
+                <dataFile>${project.build.directory}/coverage-reports/jacoco-it.exec</dataFile>
+                <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
 
         <!-- BUILD HELPER (version) -->
         <plugin>
@@ -538,57 +643,6 @@
             <keepBranch>false</keepBranch>
             <pushRemote>true</pushRemote>
           </configuration>
-        </plugin>
-
-        <!-- [TEST] JACOCO (version, setup) -->
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.12</version>
-          <executions>
-            <execution>
-              <id>pre-unit-test</id>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-              <configuration>
-                <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-                <propertyName>surefireArgLine</propertyName>
-              </configuration>
-            </execution>
-            <execution>
-              <id>pre-integration-test</id>
-              <goals>
-                <goal>prepare-agent-integration</goal>
-              </goals>
-              <configuration>
-                <destFile>${project.build.directory}/coverage-reports/jacoco-it.exec</destFile>
-                <propertyName>failsafeArgLine</propertyName>
-              </configuration>
-            </execution>
-            <execution>
-              <id>post-unit-test</id>
-              <phase>test</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-              <configuration>
-                <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-                <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-              </configuration>
-            </execution>
-            <execution>
-              <id>post-integration-test</id>
-              <phase>post-integration-test</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-              <configuration>
-                <dataFile>${project.build.directory}/coverage-reports/jacoco-it.exec</dataFile>
-                <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
 
         <!-- [TEST] - JGIVEN (version, configuration, execution) -->
@@ -645,6 +699,11 @@
           </configuration>
         </plugin>
 
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.13</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -698,20 +757,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                  <!-- also seen: jar ... which to choose? -->
-                </goals>
-                <configuration>
-                  <attach>true</attach>
-                  <forceCreation>true</forceCreation>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -749,7 +794,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.3.0</version>
             <configuration>
               <archive>
                 <manifest>
@@ -760,35 +804,16 @@
             </configuration>
           </plugin>
 
-          <!-- [RELEASE] GPG (version, configuration, execution)-->
+          <!-- [RELEASE] GPG -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <configuration>
-              <!-- pass -Dgpg.keyname=.. and -Dgpg.passphrase=... -->
-              <gpgArguments>
-                <arg>--batch</arg>
-                <arg>--yes</arg>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
 
           <!-- [RELEASE] NEXUS (version, config, execution) -->
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
             <configuration>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
               <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <kp.compile.useIncrementalKotlinCompiler>false</kp.compile.useIncrementalKotlinCompiler>
     <kp.patternClassITest>**/*ITest.*</kp.patternClassITest>
     <kp.patternClassTCTest>**/*TCTest.*</kp.patternClassTCTest>
+    <kp.javaOpenModules>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED</kp.javaOpenModules>
     <kp.skipITests>false</kp.skipITests>
 
     <!-- LANGUAGE VERSIONS -->
@@ -455,7 +456,7 @@
               <exclude>${kp.patternClassTCTest}</exclude>
             </excludes>
             <!--suppress UnresolvedMavenProperty -->
-            <argLine>${surefireArgLine} -Djava.awt.headless=true -XX:+StartAttachListener --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+            <argLine>${surefireArgLine} ${kp.javaOpenModules} -Djava.awt.headless=true -XX:+StartAttachListener</argLine>
             <systemPropertyVariables>
               <jgiven.report.dir>${project.build.directory}/jgiven-reports/json</jgiven.report.dir>
             </systemPropertyVariables>
@@ -475,7 +476,7 @@
               <include>${kp.patternClassTCTest}</include>
             </includes>
             <!--suppress UnresolvedMavenProperty -->
-            <argLine>${failsafeArgLine} --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+            <argLine>${failsafeArgLine} ${kp.javaOpenModules} -Djava.awt.headless=true -XX:+StartAttachListener</argLine>
             <systemPropertyVariables>
               <jgiven.report.dir>${project.build.directory}/jgiven-reports/json</jgiven.report.dir>
             </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,6 @@
               <!--              <option>all-open:annotation=javax.persistence.Embeddable</option>-->
               <option>all-open:annotation=io.toolisticon.testing.jgiven.JGivenKotlinStage</option>
             </pluginOptions>
-            <annotationProcessorPaths/>
           </configuration>
 
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
   </dependencyManagement>
 
   <build>
-    <defaultGoal>clean jacoco:prepare-agent package</defaultGoal>
+    <defaultGoal>clean package</defaultGoal>
 
     <sourceDirectory>${kp.mainSources}</sourceDirectory>
     <testSourceDirectory>${kp.testSources}</testSourceDirectory>


### PR DESCRIPTION
:zap: probably breaking, but for a good reason

- new ADR: plugin version is always defined in `pluginManagement`
- new ADR: if only one usage is desired, define the configuration and execution in `pluginManagement` and reference the plugin in default build or in a profile only.
- jacoco is included into default build
- failsafe and jacoco plugin respects a new flag `kp.skipITests`
- two properties for ITests and TCTests are defined: `kp.patternClassITest` and `kp.patternClassTCTest` which are paterns excluded by surefire and included by failsafe.
- correct system property is set for jgiven to be able to generate HTML reports out of json data
- `--add-opens=java.base/java.util=ALL-UNNAMED` added to surefire and failsafe run
- fix #53 